### PR TITLE
Modify the duplicate email registration message for teacher, student,…

### DIFF
--- a/client/src/app/components/manager/register/register-secretary/register-secretary.component.ts
+++ b/client/src/app/components/manager/register/register-secretary/register-secretary.component.ts
@@ -142,8 +142,15 @@ export class RegisterSecretaryComponent {
       },
       error: err => {
         const msgs: string[] = Array.isArray(err?.error) ? err.error : (Array.isArray(err?.error?.errors) ? err.error.errors : []);
-        if (msgs.length) this.applyServerErrorsToForm(msgs);
-        this.openSnack('خطا در ثبت نام.', 'error');
+
+        if (msgs.length) {
+          this.applyServerErrorsToForm(msgs);
+
+          this.openSnack(msgs.join('\n'), 'error');
+        }
+        else {
+          this.openSnack('خطا در ثبت نام', 'error');
+        }
       }
     });
   }

--- a/client/src/app/components/manager/register/register-student/register-student.component.ts
+++ b/client/src/app/components/manager/register/register-student/register-student.component.ts
@@ -142,8 +142,15 @@ export class RegisterStudentComponent {
       },
       error: err => {
         const msgs: string[] = Array.isArray(err?.error) ? err.error : (Array.isArray(err?.error?.errors) ? err.error.errors : []);
-        if (msgs.length) this.applyServerErrorsToForm(msgs);
-        this.openSnack('خطا در ثبت نام.', 'error');
+
+        if (msgs.length) {
+          this.applyServerErrorsToForm(msgs);
+
+          this.openSnack(msgs.join('\n'), 'error');
+        }
+        else {
+          this.openSnack('خطا در ثبت نام', 'error');
+        }
       }
     });
   }

--- a/client/src/app/components/manager/register/register-teacher/register-teacher.component.ts
+++ b/client/src/app/components/manager/register/register-teacher/register-teacher.component.ts
@@ -142,8 +142,15 @@ export class RegisterTeacherComponent {
       },
       error: err => {
         const msgs: string[] = Array.isArray(err?.error) ? err.error : (Array.isArray(err?.error?.errors) ? err.error.errors : []);
-        if (msgs.length) this.applyServerErrorsToForm(msgs);
-        this.openSnack('خطا در ثبت نام.', 'error');
+
+        if (msgs.length) {
+          this.applyServerErrorsToForm(msgs);
+
+          this.openSnack(msgs.join('\n'), 'error');
+        }
+        else {
+          this.openSnack('خطا در ثبت نام', 'error');
+        }
       }
     });
   }


### PR DESCRIPTION
On the teacher, student, and secretary pages,
when submitting information with a duplicate email,
an appropriate message is displayed: "این ایمیل قبلاً ثبت شده است"
(The message configured in the back-end is displayed)