### PR TITLE
Removing one of the arrows at the top of the page on the courses page in mobile size

### DIFF
--- a/client/src/app/components/courses/course-list/course-list.component.scss
+++ b/client/src/app/components/courses/course-list/course-list.component.scss
@@ -21,6 +21,10 @@
         margin-top: 8.5rem;
         margin-bottom: 1.5rem;
 
+        .bf-btns {
+            display: none;
+        }
+
         span {
             font-size: 35px;
             color: black;
@@ -127,6 +131,10 @@
     .courses-container {
         .div-title-course {
             margin-top: 8rem;
+
+            .bf-btns {
+                display: flex;
+            }
         }
     }
 }


### PR DESCRIPTION
The extra arrow that was displayed at the top of the page in mobile and tablet sizes has been removed.
