### PR TITLE
 Trim department before saving in to database

### DIFF
--- a/backend/api/DTOs/_Mappers.cs
+++ b/backend/api/DTOs/_Mappers.cs
@@ -134,7 +134,7 @@ public static class Mappers
          new()
          {
              Name = request.Name.ToLower().Trim(),
-             Department = request.Department,
+             Department = request.Department.Trim(),
              Floor = request.Floor,
              Capacity = request.Capacity
          };

--- a/backend/api/Repositories/SiteRepository.cs
+++ b/backend/api/Repositories/SiteRepository.cs
@@ -115,7 +115,7 @@ public class SiteRepository : ISiteRepository
             updateDefinitions.Add(builder.Set(doc => doc.Name, request.Name));
 
         if (!string.Equals(targetSite.Department, request.Department, StringComparison.Ordinal))
-            updateDefinitions.Add(builder.Set(doc => doc.Department, request.Department));
+            updateDefinitions.Add(builder.Set(doc => doc.Department, request.Department.Trim()));
 
         if (!int.Equals(targetSite.Floor, request.Floor))
             updateDefinitions.Add(builder.Set(doc => doc.Floor, request.Floor));


### PR DESCRIPTION
Untrimmed department values could be persisted,
leading to data inconsistency and faulty lookups.